### PR TITLE
Fixed QML module copy for parallel QtQuick.Controls/Controls2 use

### DIFF
--- a/mxedeployqt
+++ b/mxedeployqt
@@ -143,11 +143,11 @@ def copy_qmlmodules(qmake, qmlimportscanner, qmlrootpath, qmlmodules, target, sk
 
         #Only copy the outermost directory when there are nested directories
         sorted_modules = sorted(used_qmlmodules.keys(), key=lambda x: (x, len(x)))
-        copied_dirs = []
+        copied_dirs = set()
         for module_source in sorted_modules:
             if os.path.abspath(os.path.join(module_source, os.pardir)) not in copied_dirs:
                 copy_dir(module_source, used_qmlmodules[module_source], skip)
-                copied_dirs.append(module_source)
+                copied_dirs.add(module_source)
     else:
         logging.error("Unable to retrieve QT_INSTALL_QMLS from qmake")
 


### PR DESCRIPTION
Fixes #1 

When QtQuick.Controls and QtQuick.Controls2 are used in parallel, module paths are not sorted as expected by the copy algorithm. Maintaining a list of copied paths resolves this by not assuming the previous path in the sorted list would be the potential parent.

The root cause is the logic used in the copy routine, which:
1. uses a simple `find` to check if a module path has already been copied (false positive: `QtQuick/Controls` is found in `QtQuick/Controls.2`)
2. assumes child directories always appear directly after parent directories in the sorted module list

Here is the example output of the sorted module list when both QtQuick.Controls and QtQuick.Controls2 are used. Note that the sorting causes `Controls.2` to appear between `Controls` and its child directories, which additionally breaks module copying when both are used if the copy routine assumes the parent appears directly before children:

```
/usr/i686-w64-mingw32/lib/qt/qml/Qt/labs/folderlistmodel
/usr/i686-w64-mingw32/lib/qt/qml/Qt/labs/settings
/usr/i686-w64-mingw32/lib/qt/qml/QtGraphicalEffects
/usr/i686-w64-mingw32/lib/qt/qml/QtGraphicalEffects/private
/usr/i686-w64-mingw32/lib/qt/qml/QtQml
/usr/i686-w64-mingw32/lib/qt/qml/QtQml/Models.2
/usr/i686-w64-mingw32/lib/qt/qml/QtQml/WorkerScript.2
/usr/i686-w64-mingw32/lib/qt/qml/QtQuick.2
/usr/i686-w64-mingw32/lib/qt/qml/QtQuick/Controls
/usr/i686-w64-mingw32/lib/qt/qml/QtQuick/Controls.2
/usr/i686-w64-mingw32/lib/qt/qml/QtQuick/Controls.2/Fusion
/usr/i686-w64-mingw32/lib/qt/qml/QtQuick/Controls.2/Imagine
/usr/i686-w64-mingw32/lib/qt/qml/QtQuick/Controls.2/Material
/usr/i686-w64-mingw32/lib/qt/qml/QtQuick/Controls.2/Universal
/usr/i686-w64-mingw32/lib/qt/qml/QtQuick/Controls/Private
/usr/i686-w64-mingw32/lib/qt/qml/QtQuick/Controls/Styles
/usr/i686-w64-mingw32/lib/qt/qml/QtQuick/Dialogs
/usr/i686-w64-mingw32/lib/qt/qml/QtQuick/Dialogs/Private
/usr/i686-w64-mingw32/lib/qt/qml/QtQuick/Extras
/usr/i686-w64-mingw32/lib/qt/qml/QtQuick/Extras/Private
/usr/i686-w64-mingw32/lib/qt/qml/QtQuick/Layouts
/usr/i686-w64-mingw32/lib/qt/qml/QtQuick/PrivateWidgets
/usr/i686-w64-mingw32/lib/qt/qml/QtQuick/Shapes
/usr/i686-w64-mingw32/lib/qt/qml/QtQuick/Templates.2
/usr/i686-w64-mingw32/lib/qt/qml/QtQuick/Window.2
```