### PR TITLE
Follow symlinks

### DIFF
--- a/mxedeployqt
+++ b/mxedeployqt
@@ -157,7 +157,7 @@ def find_files(path):
     '''Find all files in the given path and it's subdirectories'''
     logging.info("Scanning path: " + path + " for files")
     result = []
-    for (d, _, files) in os.walk(path):
+    for (d, _, files) in os.walk(path, followlinks=True):
         for f in files:
             path = os.path.join(d, f)
             if os.path.exists(path):


### PR DESCRIPTION
It is good to follow symlinks.

In my specific Qt5 build I've set `/opt/mxe/usr/<arch>/qt5` to be symlink to `/opt/qt5/<qt-version>/<arch>`